### PR TITLE
Display yapf formatting error class and message

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,17 +34,22 @@ def index():
         source = request.form['source']
         style_config = request.form['style_config']
 
+    error = ''
+    error_class = ''
+
     try:
         formatted, _ = yapf_api.FormatCode(source, style_config=style_config)
-        error = None
-    except Exception as error:
+    except Exception as e:
         formatted = ''
+        error = e
+        error_class = e.__class__.__name__
 
     data = {
         'source': source,
         'formatted': formatted,
         'style_config': style_config,
         'error': error,
+        'error_class': error_class,
         'yapf_version': yapf.__version__
     }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -76,7 +76,7 @@
           <div class="col-md-12">
             <div class="alert alert-danger alert-dismissible">
               <button type="button" class="close" data-dismiss="alert"><span>&times;</span></button>
-              <strong>Oops!</strong> Exception: {{ error }}
+              <strong>Oops!</strong> {{error_class}}: {{ error }}
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR fixes an error where if yapf raised an exception it would result in
an unbound variable error for the variable 'error', because it had the same name
as the Exception aliased as 'error'. This PR uses different names for the Exception
alias and the error string. It also adds the error class as template context to
display the error type to the User.

closes #2 

Here's a screenshot of the error message now:

<img width="688" alt="screen shot 2018-05-08 at 7 51 24 am" src="https://user-images.githubusercontent.com/5514112/39764568-c16876ca-5294-11e8-8b1f-11d5d45a408a.png">
